### PR TITLE
Add an interface and trait for Eloquent models

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ This facade will dynamically pass static method calls to the `hashids` object in
 
 This class contains no public methods of interest. This class should be added to the providers array in `config/app.php`. This class will setup ioc bindings.
 
+#### Eloquent\HasHashid
+
+An interface to add to your Eloquent models from which you can get a hashid.
+It describes a `getHashidAttribute` method, accessible (via Eloquent's dynamic property resolution) as `$model->hashid`, and two static methods `findHashid` and `findHashidOrFail`.
+The find methods take a `$hashid` parameter and by default except this hashid to encode a single integer.
+If you instead want to handle hashids which encode multiple integers, you can pass `true` as the second parameter to either of these methods.
+
+#### Eloquent\HashidTrait
+
+This trait is an implementation of the `HasHashid` interface for Eloquent models.
+It uses the main connection to encode and decode hashids in the context of a given model.
+
 ### Examples
 Here you can see an example of just how simple this package is to use. Out of the box, the default adapter is `main`. After you enter your authentication details in the config file, it will just work:
 
@@ -131,6 +143,30 @@ class Foo
 
 App::make('Foo')->bar();
 ```
+
+### Usage with Eloquent models
+
+If you want to add a hashid getter to an Eloquent model, one way is to use the provided interface and trait.
+Once added, your model may begin something like this:
+
+```php
+<?php
+
+namespace App
+
+use Illuminate\Database\Eloquent\Model;
+use Vinkla\Hashids\Eloquent\HasHashid;
+use Vinkla\Hashids\Eloquent\HashidTrait;
+
+class Foo extends Model implements HasHashid
+{
+    use HashidTrait;
+
+…
+```
+
+You can then get a hashid with `$foo->hashid`, and retrieve the model with
+`App\Foo::findHashid($hashid)` or `App\Foo::findHashidOrFail($hashid)`.
 
 ## Documentation
 

--- a/src/Eloquent/HasHashid.php
+++ b/src/Eloquent/HasHashid.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Vinkla\Hashids\Eloquent;
+
+interface HasHashid
+{
+    /**
+     * Get the hashid of this model.
+     *
+     * @return string
+     */
+    public function getHashidAttribute();
+
+    /**
+     * Find the model or models described by a given hashid.
+     *
+     * @param string $hashid The hashid to decode
+     * @param bool $multiple If false (default) the hashid is expected to encode
+     * a single integer, and a single matching model or null will be returned;
+     * if it does not encode a single integer, null is returned. If true, an
+     * array of IDs (possibly empty) is searched for, and an instance of
+     * Illuminate\Database\Eloquent\Collection is returned.
+     *
+     * @return mixed
+     */
+    public static function findHashid(string $hashid, bool $multiple = false);
+
+    /**
+     * Find the model or models described by a given hashid or throw an
+     * exception.
+     *
+     * @param string $hashid The hashid to decode
+     * @param bool $multiple If false (default) the hashid is expected to encode
+     * a single integer, and a single matching model will be returned; if it
+     * does not encode a single integer, an \InvalidArgumentException is thrown.
+     * If true, an array of IDs (possibly empty) is searched for, and an
+     * instance of \Illuminate\Database\Eloquent\Collection is returned if all
+     * members are found; otherwise, an
+     * \Illuminate\Database\Eloquent\ModelNotFoundException is thrown.
+     *
+     * @return mixed
+     */
+    public static function findHashidOrFail(string $hashid, bool $multiple = false);
+}

--- a/src/Eloquent/HashidTrait.php
+++ b/src/Eloquent/HashidTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Vinkla\Hashids\Eloquent;
+
+trait HashidTrait
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getHashidAttribute()
+    {
+        return app('hashids')->encode($this->getKey());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function findHashid(string $hashid, bool $multiple = false)
+    {
+        $ids = app('hashids')->decode($hashid);
+        if ($multiple) {
+            return self::find($ids);
+        }
+        if (count($ids) !== 1) {
+            return;
+        }
+
+        return self::find($ids[0]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function findHashidOrFail(string $hashid, bool $multiple = false)
+    {
+        $ids = app('hashids')->decode($hashid);
+        if ($multiple) {
+            return self::findOrFail($ids);
+        }
+        if (count($ids) !== 1) {
+            throw new \InvalidArgumentException(
+                'Expected a hashid encoding exactly one integer'
+            );
+        }
+
+        return self::findOrFail($ids[0]);
+    }
+}


### PR DESCRIPTION
These make it a simple process to add methods to Eloquent models to retrieve an instance's hashid, and to find a model based on its hashid.

I find myself frequently adding these to projects, and it'd be nice if they were bundled with the bridge.

I haven't written tests, and they are not thoroughly tested. Before doing any of that I want to gauge your interest in accepting this feature.