### PR TITLE
Changed result

### DIFF
--- a/src/Facades/Hashids.php
+++ b/src/Facades/Hashids.php
@@ -46,10 +46,8 @@ class Hashids extends Facade
     
     /**
      * Decode the value.
-     * If hash is numeric, or an array of numeric characters, then return the hash as it is,
-     * since nothing can be decoded from that.
      *
-     * @param $hash string|array String hash value to be decoded.
+     * @param $hash string String hash value to be decoded.
      *
      * @return mixed|int
      */

--- a/src/Facades/Hashids.php
+++ b/src/Facades/Hashids.php
@@ -55,11 +55,6 @@ class Hashids extends Facade
      */
     public static function decode($hash)
     {
-        if (is_numeric($hash)) return $hash;
-        if (is_array($hash)) {
-            if (empty($hash)) return [];
-            if (count($hash) == count(array_filter(array_map('is_numeric', $hash)))) return $hash;
-        }
         return self::optimize(parent::decode($hash));
     }
     

--- a/src/Facades/Hashids.php
+++ b/src/Facades/Hashids.php
@@ -31,4 +31,49 @@ class Hashids extends Facade
     {
         return 'hashids';
     }
+    
+    /**
+     * Encode an integer/array and return hash.
+     *
+     * @param $ints int|mixed value to be encoded/hashed
+     *
+     * @return string Hash value
+     */
+    public static function encode($ints)
+    {
+        return self::optimize(parent::encode($ints));
+    }
+    
+    /**
+     * Decode the value.
+     * If hash is numeric, or an array of numeric characters, then return the hash as it is,
+     * since nothing can be decoded from that.
+     *
+     * @param $hash string|array String hash value to be decoded.
+     *
+     * @return mixed|int
+     */
+    public static function decode($hash)
+    {
+        if (is_numeric($hash)) return $hash;
+        if (is_array($hash)) {
+            if (empty($hash)) return [];
+            if (count($hash) == count(array_filter(array_map('is_numeric', $hash)))) return $hash;
+        }
+        return self::optimize(parent::decode($hash));
+    }
+    
+    /**
+     * Optimize the result to ensure if it is single result,
+     * we get single output otherwise get result as sent.
+     *
+     * @param $result array|int|string
+     *
+     * @return mixed
+     */
+    protected static function optimize($result)
+    {
+        if (is_array($result) && 1 == count($result)) return $result[0];
+        return $result;
+    }
 }


### PR DESCRIPTION
Practical implementation of Hashids::decode and Hashids::encode methods in the class.
This is to produce non-array result in cases of single result for both functions.
```
/* Expected output */
$hash = Hashids::encode(12); // = ['uiyhg78k']
$id = Hashids::decode('uiyhg78k'); // = [12]

/* The new result set */
$hash = Hashids::encode(12); // = 'uiyhg78k'
$id = Hashids::decode('uiyhg78k'); // = 12
```

This will see direct usage of the result without extra extraction of value from the array result. It can therefore be used directly as;
`{{url('category/edit')}}/{{Hashids::encode(12)}}`

Also is a great boost for intellisense. Was having hard time ignoring the warnings on **_Method not Found_**.