### PR TITLE
Added the key "alphabet" in hashdis config file

### DIFF
--- a/config/hashids.php
+++ b/config/hashids.php
@@ -42,11 +42,13 @@ return [
         'main' => [
             'salt' => 'your-salt-string',
             'length' => 'your-length-integer',
+            'alphabet' => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
         ],
 
         'alternative' => [
             'salt' => 'your-salt-string',
             'length' => 'your-length-integer',
+            'alphabet' => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
         ],
 
     ],


### PR DESCRIPTION
The class HashidsFactory allows the parameter "alphabet" but it is not present in the config file.