### PR TITLE
This trait provides various short hand support over Model Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ This is the class of most interest. It is bound to the ioc container as `hashids
 
 This facade will dynamically pass static method calls to the `hashids` object in the ioc container which by default is the `HashidsManager` class.
 
+#### Traits\Hashidable
+
+This trait will add various shorthand support directly on Model class which will help faster access to encoding/decoding of hash for id's or any other string specific to that particular `Model`.
+
 #### HashidsServiceProvider
 
 This class contains no public methods of interest. This class should be added to the providers array in `config/app.php`. This class will setup ioc bindings.
@@ -126,6 +130,32 @@ class Foo
 
 App::make('Foo')->bar();
 ```
+
+If you prefer using a Trait extended to your Model class
+
+```php
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Vinkla\Hashids\Traits\Hashidable;
+
+class Foo extends Model
+{
+    use Hashidable;
+}
+
+Foo::encodeKey('1');        // generates hash key
+Foo::decodeKey('hash_key'); // decodes to actual key value
+
+$foo = new Foo;
+$foo->name = 'Hello';
+$foo->save();
+
+$foo->route_key;  // Provides hash key
+$foo->show_route; // Provides resource route for show as "/foos/{hash_key}"
+$foo->edit_route; // Provides resource route for edit as "/foos/{hash_key}/edit"
+```
+
 
 ## Documentation
 

--- a/src/Traits/Hashidable.php
+++ b/src/Traits/Hashidable.php
@@ -1,0 +1,133 @@
+<?php
+
+declare (strict_types = 1);
+
+namespace Vinkla\Hashids\Traits;
+
+use Vinkla\Hashids\Facades\Hashids;
+
+/**
+ * This is the Hashidable trait class.
+ *
+ * @author Rohan Sakhale <rs@saiashirwad.com>
+ */
+trait Hashidable
+{
+
+    /**
+     * Encode key's directly for specific to calling Model class
+     *
+     * @example
+     *      {ModelClass}::encodeKey($key)
+     *
+     * @param $key
+     */
+    public function scopeEncodeKey($query, $key)
+    {
+        return Hashids::connection(get_called_class())->encode($key);
+    }
+
+    /**
+     * Decode provided hash into proper value using calling Model class
+     *
+     * @example
+     *      {ModelClass}::decodeKey($hash)
+     *
+     * @param $hash
+     */
+    public function scopeDecodeKey($query, $hash)
+    {
+        return Hashids::connection(get_called_class())->decode($hash)[0] ?? false;
+    }
+
+    /**
+     * Short hand method to directly find Model Object by Hashed Key
+     *
+     * @example
+     *      {ModelClass}::findByKey($hash)
+     *
+     * @param $query
+     * @param $hash
+     *
+     * @return
+     *      Model Object or null
+     */
+    public function scopeFindByKey($query, $hash)
+    {
+        $id = $this->scopeDecodeKey($query, $hash);
+        if ($id) {
+            return $this->find($id);
+        }
+        return null;
+    }
+
+    /**
+     * Get Hashed key for Model object
+     *
+     * @return mixed
+     */
+    public function getRouteKey()
+    {
+        return $this->encodeKey($this->getKey());
+    }
+
+    /**
+     * Get the route key directly as attribute for Model Object
+     *
+     * @example
+     *      $model->route_key
+     *
+     * @return mixed
+     */
+    public function getRouteKeyAttribute()
+    {
+        return $this->getRouteKey();
+    }
+
+    /**
+     *  Get the URL by resource route mechanim
+     *
+     * @param $mode - should be supported by the resourcde route
+     *
+     * @return string link
+     */
+    public function getRoute($mode)
+    {
+        return route($this->getTable() . '.' . $mode, [
+            str_singular($this->getTable()) => $this->getRouteKey(),
+        ]);
+    }
+
+    /**
+     * Short hand mechanism to generate show route URL for model object
+     *
+     * @example
+     *      $model->show_route  // /models/{route_key}
+     *
+     * @return mixed
+     */
+    public function getShowRouteAttribute()
+    {
+        return $this->getRoute('show');
+    }
+
+    /**
+     * Short hand mechanism to generate edit route URL for model object
+     *
+     * @example
+     *      $model->show_route  // /models/{route_key}/edit
+     * @return mixed
+     */
+    public function getEditRouteAttribute()
+    {
+        return $this->getRoute('edit');
+    }
+
+    /**
+     * @return mixed
+     */
+    public function toClass()
+    {
+        return $this->getTable();
+    }
+}

--- a/src/Traits/Hashidable.php
+++ b/src/Traits/Hashidable.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Vinkla\Hashids\Traits;
 
@@ -15,7 +15,7 @@ trait Hashidable
 {
 
     /**
-     * Encode key's directly for specific to calling Model class
+     * Encode key's directly for specific to calling Model class.
      *
      * @example
      *      {ModelClass}::encodeKey($key)
@@ -28,7 +28,7 @@ trait Hashidable
     }
 
     /**
-     * Decode provided hash into proper value using calling Model class
+     * Decode provided hash into proper value using calling Model class.
      *
      * @example
      *      {ModelClass}::decodeKey($hash)
@@ -41,7 +41,7 @@ trait Hashidable
     }
 
     /**
-     * Short hand method to directly find Model Object by Hashed Key
+     * Short hand method to directly find Model Object by Hashed Key.
      *
      * @example
      *      {ModelClass}::findByKey($hash)
@@ -62,7 +62,7 @@ trait Hashidable
     }
 
     /**
-     * Get Hashed key for Model object
+     * Get Hashed key for Model object.
      *
      * @return mixed
      */
@@ -72,7 +72,7 @@ trait Hashidable
     }
 
     /**
-     * Get the route key directly as attribute for Model Object
+     * Get the route key directly as attribute for Model Object.
      *
      * @example
      *      $model->route_key
@@ -85,7 +85,7 @@ trait Hashidable
     }
 
     /**
-     *  Get the URL by resource route mechanim
+     *  Get the URL by resource route mechanism.
      *
      * @param $mode - should be supported by the resourcde route
      *
@@ -99,7 +99,7 @@ trait Hashidable
     }
 
     /**
-     * Short hand mechanism to generate show route URL for model object
+     * Short hand mechanism to generate show route URL for model object.
      *
      * @example
      *      $model->show_route  // /models/{route_key}
@@ -112,7 +112,7 @@ trait Hashidable
     }
 
     /**
-     * Short hand mechanism to generate edit route URL for model object
+     * Short hand mechanism to generate edit route URL for model object.
      *
      * @example
      *      $model->show_route  // /models/{route_key}/edit

--- a/src/Traits/Hashidable.php
+++ b/src/Traits/Hashidable.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Vinkla\Hashids\Traits;
 
@@ -13,7 +13,6 @@ use Vinkla\Hashids\Facades\Hashids;
  */
 trait Hashidable
 {
-
     /**
      * Encode key's directly for specific to calling {ModelClass}.
      *
@@ -94,7 +93,7 @@ trait Hashidable
      */
     public function getRoute($mode)
     {
-        return route($this->getTable() . '.' . $mode, [
+        return route($this->getTable().'.'.$mode, [
             str_singular($this->getTable()) => $this->getRouteKey(),
         ]);
     }

--- a/src/Traits/Hashidable.php
+++ b/src/Traits/Hashidable.php
@@ -57,8 +57,9 @@ trait Hashidable
         $id = $this->scopeDecodeKey($query, $hash);
         if ($id) {
             return $this->find($id);
+        } else {
+            return null;
         }
-        return null;
     }
 
     /**
@@ -93,7 +94,7 @@ trait Hashidable
      */
     public function getRoute($mode)
     {
-        return route($this->getTable() . '.' . $mode, [
+        return route($this->getTable().'.'.$mode, [
             str_singular($this->getTable()) => $this->getRouteKey(),
         ]);
     }
@@ -116,6 +117,7 @@ trait Hashidable
      *
      * @example
      *      $model->show_route  // /models/{route_key}/edit
+     * 
      * @return mixed
      */
     public function getEditRouteAttribute()

--- a/src/Traits/Hashidable.php
+++ b/src/Traits/Hashidable.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace Vinkla\Hashids\Traits;
 
@@ -15,10 +15,10 @@ trait Hashidable
 {
 
     /**
-     * Encode key's directly for specific to calling Model class.
+     * Encode key's directly for specific to calling {ModelClass}.
      *
      * @example
-     *      {ModelClass}::encodeKey($key)
+     *      \Vinkla\Tests\Hashids\TestModel::encodeKey($key)
      *
      * @param $key
      */
@@ -28,10 +28,10 @@ trait Hashidable
     }
 
     /**
-     * Decode provided hash into proper value using calling Model class.
+     * Decode provided hash into proper value using calling {ModelClass}.
      *
      * @example
-     *      {ModelClass}::decodeKey($hash)
+     *      \Vinkla\Tests\Hashids\TestModel::decodeKey($hash)
      *
      * @param $hash
      */
@@ -41,16 +41,16 @@ trait Hashidable
     }
 
     /**
-     * Short hand method to directly find Model Object by Hashed Key.
+     * Short hand method to directly find {ModelObject] by Hashed Key.
      *
      * @example
-     *      {ModelClass}::findByKey($hash)
+     *      \Vinkla\Tests\Hashids\TestModel::findByKey($hash)
      *
      * @param $query
      * @param $hash
      *
      * @return
-     *      Model Object or null
+     *      \Vinkla\Tests\Hashids\TestModel|null
      */
     public function scopeFindByKey($query, $hash)
     {
@@ -58,12 +58,12 @@ trait Hashidable
         if ($id) {
             return $this->find($id);
         } else {
-            return null;
+            return;
         }
     }
 
     /**
-     * Get Hashed key for Model object.
+     * Get Hashed key for \Vinkla\Tests\Hashids\TestModel.
      *
      * @return mixed
      */
@@ -73,7 +73,7 @@ trait Hashidable
     }
 
     /**
-     * Get the route key directly as attribute for Model Object.
+     * Get the route key directly as attribute for {ModelObject].
      *
      * @example
      *      $model->route_key
@@ -94,13 +94,13 @@ trait Hashidable
      */
     public function getRoute($mode)
     {
-        return route($this->getTable().'.'.$mode, [
+        return route($this->getTable() . '.' . $mode, [
             str_singular($this->getTable()) => $this->getRouteKey(),
         ]);
     }
 
     /**
-     * Short hand mechanism to generate show route URL for model object.
+     * Short hand mechanism to generate show route URL for {ModelObject].
      *
      * @example
      *      $model->show_route  // /models/{route_key}
@@ -113,11 +113,11 @@ trait Hashidable
     }
 
     /**
-     * Short hand mechanism to generate edit route URL for model object.
+     * Short hand mechanism to generate edit route URL for {ModelObject].
      *
      * @example
      *      $model->show_route  // /models/{route_key}/edit
-     * 
+     *
      * @return mixed
      */
     public function getEditRouteAttribute()

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Vinkla\Tests\Hashids;
+
+use Illuminate\Database\Eloquent\Model;
+use Vinkla\Hashids\Traits\Hashidable;
+
+class TestModel extends Model
+{
+    use Hashidable;
+}


### PR DESCRIPTION
This trait will add various shorthand support directly on Model class which will help faster access to encoding/decoding of hash for id's or any other string specific to that particular `Model`.

### Example

```php
namespace App;

use Illuminate\Database\Eloquent\Model;
use Vinkla\Hashids\Traits\Hashidable;

class Foo extends Model
{
    use Hashidable;
}

Foo::encodeKey('1');        // generates hash key
Foo::decodeKey('hash_key'); // decodes to actual key value

$foo = new Foo;
$foo->name = 'Hello';
$foo->save();

$foo->route_key;  // Provides hash key
$foo->show_route; // Provides resource route for show as "/foos/{hash_key}"
$foo->edit_route; // Provides resource route for edit as "/foos/{hash_key}/edit"
```