### PR TITLE
Provide method hints on Hashids Facade

### DIFF
--- a/src/Facades/Hashids.php
+++ b/src/Facades/Hashids.php
@@ -19,6 +19,9 @@ use Illuminate\Support\Facades\Facade;
  * This is the Hashids facade class.
  *
  * @author Vincent Klaiber <hello@vinkla.com>
+ *
+ * @method static array decode(string $hash)
+ * @method static string encode(array|string $value)
  */
 class Hashids extends Facade
 {

--- a/src/Facades/Hashids.php
+++ b/src/Facades/Hashids.php
@@ -20,8 +20,10 @@ use Illuminate\Support\Facades\Facade;
  *
  * @author Vincent Klaiber <hello@vinkla.com>
  *
- * @method static array decode(string $hash)
- * @method static string encode(array|string $value)
+ * @method static string encode(mixed ...$numbers) Encode parameters to generate a hash.
+ * @method static array decode(string $hash) Decode a hash to the original parameter values.
+ * @method static string encodeHex(string $str) Encode hexadecimal values and generate a hash string.
+ * @method static string decodeHex(string $hash) Decode a hexadecimal hash.
  */
 class Hashids extends Facade
 {


### PR DESCRIPTION
For developers (like myself) who use an IDE its nice to have the Facade hint the method signatures. This makes using the API easier as well prevents the IDE from complaining that the method doesn't exist.

![screen shot 2018-11-24 at 10 26 25 am](https://user-images.githubusercontent.com/35218/48971810-bba39d00-efd3-11e8-98df-e8a08e0ae60d.png)
