### PR TITLE
Switch from manager by Graham Campbell to Laravel default manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "graham-campbell/manager": "^4.0",
         "hashids/hashids": "^3.0",
         "illuminate/contracts": "5.7.*",
         "illuminate/support": "5.7.*"

--- a/src/HashidsServiceProvider.php
+++ b/src/HashidsServiceProvider.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Vinkla\Hashids;
 
 use Hashids\Hashids;
-use Illuminate\Contracts\Container\Container;
-use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Container\Container;
 use Laravel\Lumen\Application as LumenApplication;
+use Illuminate\Foundation\Application as LaravelApplication;
 
 /**
  * This is the Hashids service provider class.
@@ -88,10 +88,9 @@ class HashidsServiceProvider extends ServiceProvider
     protected function registerManager(): void
     {
         $this->app->singleton('hashids', function (Container $app) {
-            $config = $app['config'];
             $factory = $app['hashids.factory'];
 
-            return new HashidsManager($config, $factory);
+            return new HashidsManager($app, $factory);
         });
 
         $this->app->alias('hashids', HashidsManager::class);


### PR DESCRIPTION
We don't need to use manager by Graham Campbell, because Laravel manager is doing the same things. So, this PR removes a Graham's manager and implements Laravel's default manager.

All public methods are working as expected.