### PR TITLE
Support php 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
 
     strategy:
       max-parallel: 5
-      fail-fast: false
       matrix:
         php: [7.2, 7.3, 7.4]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      max-parallel: 5
       matrix:
         php: [7.2, 7.3, 7.4]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      max-parallel: 5
+      fail-fast: false
       matrix:
         php: [7.2, 7.3, 7.4]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4]
+        php: [7.2, 7.3, 7.4]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.2.5",
         "graham-campbell/manager": "^4.4",
         "hashids/hashids": "^4.0",
         "illuminate/contracts": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "graham-campbell/analyzer": "^3.0",
         "graham-campbell/testbench": "^5.4",
         "mockery/mockery": "^1.3",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5|^9.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "graham-campbell/analyzer": "^3.0",
         "graham-campbell/testbench": "^5.4",
         "mockery/mockery": "^1.3",
-        "phpunit/phpunit": "^8.5|^9.0",
+        "phpunit/phpunit": "^8.5 || ^9.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "graham-campbell/analyzer": "^3.0",
         "graham-campbell/testbench": "^5.4",
         "mockery/mockery": "^1.3",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "config": {

--- a/src/HashidsManager.php
+++ b/src/HashidsManager.php
@@ -25,7 +25,10 @@ use Illuminate\Contracts\Config\Repository;
  */
 class HashidsManager extends AbstractManager
 {
-    protected HashidsFactory $factory;
+    /**
+     * @var \Vinkla\Hashids\HashidsFactory
+     */
+    protected $factory;
 
     public function __construct(Repository $config, HashidsFactory $factory)
     {


### PR DESCRIPTION
You don't really need php 7.4.
As [Laravel minimum php version is 7.2.5](https://laravel.com/docs/7.x/installation#server-requirements), I propose you to go back to that version.