### PR TITLE
Support Laravel 7.0 as well as 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "php": "^7.3 || ^8.0",
         "graham-campbell/manager": "^4.4",
         "hashids/hashids": "^4.1",
-        "illuminate/contracts": "^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/contracts": "^7.0 || ^8.0",
+        "illuminate/support": "^7.0 || ^8.0"
     },
     "require-dev": {
         "graham-campbell/analyzer": "^3.0",


### PR DESCRIPTION
Add the ability to support both 7.0 and 8.0 versions of Laravel rather than just 8.0 as suggested in #144