### PR TITLE
Php 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ composer require vinkla/hashids
 Laravel Hashids requires connection configuration. To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+$ php artisan vendor:publish --provider="Vinkla\Hashids\HashidsServiceProvider"
 ```
 
 This will create a `config/hashids.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.

--- a/config/hashids.php
+++ b/config/hashids.php
@@ -39,13 +39,13 @@ return [
 
         'main' => [
             'salt' => 'your-salt-string',
-            'length' => 'your-length-integer',
+            'length' => 7,
             // 'alphabet' => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
         ],
 
         'alternative' => [
             'salt' => 'your-salt-string',
-            'length' => 'your-length-integer',
+            'length' => 7,
             // 'alphabet' => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
         ],
 


### PR DESCRIPTION
- Touched up README to save users an extra setup step when trying to publish the package's config file
- Set config length to an int https://github.com/vinkla/laravel-hashids/issues/151