### PR TITLE
Add provider for publish command in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ composer require vinkla/hashids
 Laravel Hashids requires connection configuration. To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+$ php artisan vendor:publish --provider="Vinkla\Hashids\HashidsServiceProvider"
 ```
 
 This will create a `config/hashids.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
It might save a few seconds for people who want to install it. Seems like a common practice in Laravel ecosystem

<details>
<summary>Spatie package example</summary>

![image](https://user-images.githubusercontent.com/23292709/160799683-6c7e5deb-fdbb-43fe-a0c4-e3e8bff5365a.png)

</details>