### PR TITLE
Fixed: Unsupported operand types: int - string in PHP 8

### DIFF
--- a/config/hashids.php
+++ b/config/hashids.php
@@ -38,8 +38,8 @@ return [
     'connections' => [
 
         'main' => [
-            'salt' => 'your-salt-string',
-            'length' => 'your-length-integer',
+            'salt' => '',
+            'length' => 0,
             // 'alphabet' => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
         ],
 


### PR DESCRIPTION
This PR fixes this issue: https://github.com/vinkla/laravel-hashids/issues/159 https://github.com/vinkla/laravel-hashids/issues/151 

1. laravel new app (laravel 9 installed with PHP 8)
2. composer require vinkla/laravel-hashids
3. `Hashids::encode(1);`

the following error occurs: 

```TypeError : Unsupported operand types: int - string```

This is because this part of code:

https://github.com/vinkla/laravel-hashids/blob/29e0efdfbeede589eb2ffc381da1bf8fd77a53e2/config/hashids.php#L41-L42

This package using the values in config file which is set to 'your-length-integer', This was not an issue in php 7 but throws error in v8 and above https://3v4l.org/hm9ML

