### PR TITLE
remove dollar sign from copy command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ composer require vinkla/hashids
 Laravel Hashids requires connection configuration. To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+php artisan vendor:publish
 ```
 
 This will create a `config/hashids.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
GitHub allows the copying of code commands, however, this dollar sign is annoying when you have to remove it before pasting it into the terminal. 