### PR TITLE
Remove lumen support

### DIFF
--- a/src/HashidsServiceProvider.php
+++ b/src/HashidsServiceProvider.php
@@ -15,9 +15,7 @@ namespace Vinkla\Hashids;
 
 use Hashids\Hashids;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
-use Laravel\Lumen\Application as LumenApplication;
 
 class HashidsServiceProvider extends ServiceProvider
 {
@@ -30,11 +28,7 @@ class HashidsServiceProvider extends ServiceProvider
     {
         $source = realpath($raw = __DIR__ . '/../config/hashids.php') ?: $raw;
 
-        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
-            $this->publishes([$source => config_path('hashids.php')]);
-        } elseif ($this->app instanceof LumenApplication) {
-            $this->app->configure('hashids');
-        }
+        $this->publishes([$source => config_path('hashids.php')]);
 
         $this->mergeConfigFrom($source, 'hashids');
     }

--- a/tests/AnalysisTest.php
+++ b/tests/AnalysisTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Vinkla\Tests\Hashids;
 
 use GrahamCampbell\Analyzer\AnalysisTrait;
-use Laravel\Lumen\Application;
 use PHPUnit\Framework\TestCase;
 
 class AnalysisTest extends TestCase
@@ -28,10 +27,5 @@ class AnalysisTest extends TestCase
             realpath(__DIR__ . '/../src'),
             realpath(__DIR__),
         ];
-    }
-
-    protected function getIgnored(): array
-    {
-        return [Application::class];
     }
 }


### PR DESCRIPTION
From Lumen website:

> Note: In the years since releasing Lumen, PHP has made a variety of wonderful performance improvements. For this reason, along with the availability of [Laravel Octane](https://laravel.com/docs/octane), we no longer recommend that you begin new projects with Lumen. Instead, we recommend always beginning new projects with [Laravel](https://laravel.com/).