### PR TITLE
Defined a HashId trait that can be directly used in a model so that a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,19 @@ class Foo
 App::make('Foo')->bar();
 ```
 
+If you would like your models to automatically store hashIds while saving:
+
+```php
+use Vinkla\Hashids\Traits\UsesHashId
+
+class Post extends Model
+{
+    use HashId;
+}
+```
+
+Now when `Post` is saved, a hashId is also stored in the `hash_id` field in the database. You can update this field name in `hashids.hash_id_field` config.
+
+To defined a field to store this in the DB, you could use `$table->hashId()` in your migration (or `$table->dropHashId()` to drop the column).
+
 For more information on how to use the `Hashids\Hashids` class, check out the docs at [`hashids/hashids`](https://github.com/vinkla/hashids.php).

--- a/config/hashids.php
+++ b/config/hashids.php
@@ -42,4 +42,6 @@ return [
 
     ],
 
+    'hash_id_field' => 'hash_id',
+
 ];

--- a/src/HashidsServiceProvider.php
+++ b/src/HashidsServiceProvider.php
@@ -16,12 +16,32 @@ namespace Vinkla\Hashids;
 use Hashids\Hashids;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Schema\Blueprint;
 
 class HashidsServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
         $this->setupConfig();
+
+        $this->defineHashIdField();
+    }
+
+    private function defineHashIdField()
+    {
+        Blueprint::macro("hashId", function($name = null) {
+            /**
+             * @var \Illuminate\Database\Schema\Blueprint $this
+             */
+            return $this->string($name ?? config('hashids.hash_id_field'));
+        });
+        
+        Blueprint::macro("dropHashId", function($name = null) {
+            /**
+             * @var \Illuminate\Database\Schema\Blueprint $this
+             */
+            return $this->dropColumn($name ?? config('hashids.hash_id_field'));
+        });
     }
 
     protected function setupConfig(): void

--- a/src/Traits/HashId.php
+++ b/src/Traits/HashId.php
@@ -1,0 +1,24 @@
+<?php
+namespace Vinkla\Hashids\Traits;
+
+use Vinkla\Hashids\Facades\Hashids;
+
+trait HashId
+{
+    protected function getHashIdField()
+    {
+        return config('hashids.hash_id_field');
+    }
+
+    protected static function bootUsesHashId()
+    {
+        static::saving(function($model) {
+            $model->setAttribute($model->getHashIdField(), Hashids::encode($model->getKey()));
+        });
+    }
+
+    public function getRouteKeyName()
+    {
+        return $this->getHashIdField();
+    }
+}


### PR DESCRIPTION
… hashId is generated every time the model is saved and this is stored in the database.

This also defines `$table->hashId()` and `$table->dropHashId()` to define db fields to store the hashIds.