### PR TITLE
Update vendor:publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ composer require vinkla/hashids
 Laravel Hashids requires connection configuration. To get started, you'll need to publish all vendor assets:
 
 ```bash
-php artisan vendor:publish
+php artisan vendor:publish --provider="Vinkla\Hashids\HashidsServiceProvider"
 ```
 
 This will create a `config/hashids.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
Running:
```
php artisan vendor:publish --provider="Vinkla\Hashids\HashidsServiceProvider"
```

Will publish `config/hashids.php` immediately, without an interactive shell:
```
Copying file [vendor/vinkla/hashids/config/hashids.php] to [config/hashids.php] ............................................................. DONE
```

This PR updates the README to reflect this, making the copy/paste experience a bit better 😄 