### PR TITLE
Add `HasHashId` Eloquent trait for model-level hash ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,70 @@ class Foo
 App::make('Foo')->bar();
 ```
 
+## Eloquent Model Trait
+
+The `HasHashId` trait provides hash ID support directly on your Eloquent models.
+
+#### Setup
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Vinkla\Hashids\Concerns\HasHashId;
+
+class Post extends Model
+{
+    use HasHashId;
+}
+```
+
+To use a specific Hashids connection, define a `$connectionHashId` property on the model:
+
+```php
+class Post extends Model
+{
+    use HasHashId;
+
+    protected string $connectionHashId = 'alternative';
+
+    // Or Using the `connectionHashId` method.
+    public function getConnectionHashId(): string
+    {
+        return 'alternative';
+    }
+}
+```
+
+#### Encoding & Decoding
+
+```php
+$post = Post::find(1);
+
+// Get the hash ID for a model instance.
+$post->getHashId(); // "jR"
+
+// Access it as an attribute. when added to `$appends` property.
+protected $appends = ['hash_id'];  // in model class
+
+$post->hash_id; // "jR" 
+
+// Decode a hash ID back to its original value.
+Post::decodeHashId('jR'); // 1
+
+// Find a model by its hash ID.
+$post = Post::findByHashId('jR'); // Post instance or null
+```
+
+#### Query Scope
+
+Use `whereHashIds` to query models by one or more hash IDs:
+
+```php
+// Single hash ID.
+Post::query()->whereHashIds('jR')->first();
+
+// Multiple hash IDs (array or Collection).
+Post::query()->whereHashIds(['jR', 'oZ'])->get();
+Post::query()->whereHashIds(collect(['jR', 'oZ']))->get();
+```
+
 For more information on how to use the `Hashids\Hashids` class, check out the docs at [`hashids/hashids`](https://github.com/vinkla/hashids.php).

--- a/src/Concerns/HasHashId.php
+++ b/src/Concerns/HasHashId.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vinkla\Hashids\Concerns;
+
+use Hashids\Hashids as HashidsCore;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Support\Collection;
+use Vinkla\Hashids\Facades\Hashids;
+
+trait HasHashId
+{
+    /**
+     * Get the Hashids connection name for this model.
+     */
+    public function getConnectionHashId(): string
+    {
+        return $this->connectionHashId ?? Hashids::getDefaultConnection();
+    }
+
+    /**
+     * Resolve the Hashids instance for the model's connection.
+     */
+    protected function resolveHashId(): HashidsCore
+    {
+        return Hashids::connection($this->getConnectionHashId());
+    }
+
+    /**
+     * Find a model by its hash ID.
+     */
+    public static function findByHashId(string $hashId): ?static
+    {
+        $instance = new static;
+        $decoded = $instance->resolveHashId()->decode($hashId);
+
+        if (empty($decoded)) {
+            return null;
+        }
+
+        return static::find($decoded[0]);
+    }
+
+    /**
+     * Decode a hash ID to its original value.
+     */
+    public static function decodeHashId(string $hashId): int|string|null
+    {
+        $instance = new static;
+        $decoded = $instance->resolveHashId()->decode($hashId);
+
+        return $decoded[0] ?? null;
+    }
+
+    /**
+     * Get the hash ID for this model.
+     */
+    public function getHashId(): string
+    {
+        return $this->resolveHashId()->encode($this->getKey());
+    }
+
+    /**
+     * Accessor for the "hash_id" attribute.
+     */
+    public function hashId(): Attribute
+    {
+        return Attribute::make(get: fn () => $this->getHashId());
+    }
+
+    #[Scope]
+    protected function whereHashIds(Builder $query, string|array|Collection $hashId): Builder
+    {
+        $hashes = is_string($hashId) ? [$hashId] : ($hashId instanceof Collection ? $hashId->all() : $hashId);
+
+        $hashids = $this->resolveHashId();
+        $ids = array_filter(array_map(
+            fn (string $hash): ?int => $hashids->decode($hash)[0] ?? null,
+            $hashes,
+        ));
+
+        if (empty($ids)) {
+            return $query;
+        }
+
+        return count($ids) === 1
+            ? $query->where($this->getKeyName(), reset($ids))
+            : $query->whereIn($this->getKeyName(), $ids);
+    }
+}

--- a/tests/Concerns/FakeModel.php
+++ b/tests/Concerns/FakeModel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vinkla\Tests\Hashids\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Vinkla\Hashids\Concerns\HasHashId;
+
+class FakeModel extends Model
+{
+    use HasHashId;
+
+    protected $guarded = [];
+}

--- a/tests/Concerns/FakeModelWithCustomConnection.php
+++ b/tests/Concerns/FakeModelWithCustomConnection.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vinkla\Tests\Hashids\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Vinkla\Hashids\Concerns\HasHashId;
+
+class FakeModelWithCustomConnection extends Model
+{
+    use HasHashId;
+
+    protected string $connectionHashId = 'custom';
+
+    protected $guarded = [];
+}

--- a/tests/Concerns/HasHashIdTest.php
+++ b/tests/Concerns/HasHashIdTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vinkla\Tests\Hashids\Concerns;
+
+use Hashids\Hashids as HashidsCore;
+use Mockery;
+use Mockery\MockInterface;
+use Vinkla\Hashids\Facades\Hashids;
+use Vinkla\Tests\Hashids\AbstractTestCase;
+
+class HasHashIdTest extends AbstractTestCase
+{
+    private function mockHashids(): HashidsCore&MockInterface
+    {
+        $mock = Mockery::mock(HashidsCore::class);
+
+        Hashids::shouldReceive('getDefaultConnection')->andReturn('main');
+        Hashids::shouldReceive('connection')->with('main')->andReturn($mock);
+
+        return $mock;
+    }
+
+    public function testGetHashIdEncodesModelKey(): void
+    {
+        $this->mockHashids()->shouldReceive('encode')->with(1)->once()->andReturn('jR');
+
+        $this->assertSame('jR', (new FakeModel(['id' => 1]))->getHashId());
+    }
+
+    public function testHashIdAttributeMatchesGetHashId(): void
+    {
+        $this->mockHashids()->shouldReceive('encode')->with(5)->andReturn('oZ');
+
+        $model = new FakeModel(['id' => 5]);
+
+        $this->assertSame($model->getHashId(), $model->hash_id);
+    }
+
+    public function testDecodeHashIdReturnsOriginalValue(): void
+    {
+        $this->mockHashids()->shouldReceive('decode')->with('jR')->once()->andReturn([1]);
+
+        $this->assertSame(1, FakeModel::decodeHashId('jR'));
+    }
+
+    public function testDecodeHashIdReturnsNullForInvalidHash(): void
+    {
+        $this->mockHashids()->shouldReceive('decode')->with('invalid')->once()->andReturn([]);
+
+        $this->assertNull(FakeModel::decodeHashId('invalid'));
+    }
+
+    public function testGetConnectionHashIdReturnsDefaultConnection(): void
+    {
+        Hashids::shouldReceive('getDefaultConnection')->once()->andReturn('main');
+
+        $this->assertSame('main', (new FakeModel())->getConnectionHashId());
+    }
+
+    public function testGetConnectionHashIdReturnsCustomConnection(): void
+    {
+        $this->assertSame('custom', (new FakeModelWithCustomConnection())->getConnectionHashId());
+    }
+
+    public function testWhereHashIdsWithSingleString(): void
+    {
+        $this->mockHashids()->shouldReceive('decode')->with('jR')->once()->andReturn([1]);
+
+        $query = FakeModel::query()->whereHashIds('jR');
+
+        $this->assertSame('select * from "fake_models" where "id" = ?', $query->toSql());
+        $this->assertSame([1], $query->getBindings());
+    }
+
+    public function testWhereHashIdsWithArray(): void
+    {
+        $mock = $this->mockHashids();
+        $mock->shouldReceive('decode')->with('jR')->once()->andReturn([1]);
+        $mock->shouldReceive('decode')->with('oZ')->once()->andReturn([5]);
+
+        $query = FakeModel::query()->whereHashIds(['jR', 'oZ']);
+
+        $this->assertSame('select * from "fake_models" where "id" in (?, ?)', $query->toSql());
+        $this->assertSame([1, 5], $query->getBindings());
+    }
+
+    public function testWhereHashIdsWithCollection(): void
+    {
+        $mock = $this->mockHashids();
+        $mock->shouldReceive('decode')->with('jR')->once()->andReturn([1]);
+        $mock->shouldReceive('decode')->with('oZ')->once()->andReturn([5]);
+
+        $query = FakeModel::query()->whereHashIds(collect(['jR', 'oZ']));
+
+        $this->assertSame('select * from "fake_models" where "id" in (?, ?)', $query->toSql());
+        $this->assertSame([1, 5], $query->getBindings());
+    }
+
+    public function testWhereHashIdsWithInvalidHashAddsNoConstraint(): void
+    {
+        $this->mockHashids()->shouldReceive('decode')->with('invalid')->once()->andReturn([]);
+
+        $query = FakeModel::query()->whereHashIds('invalid');
+
+        $this->assertSame('select * from "fake_models"', $query->toSql());
+        $this->assertEmpty($query->getBindings());
+    }
+}


### PR DESCRIPTION
Introduces a `HasHashId` trait that integrates Hashids directly into Eloquent models, providing a convenient API for encoding, decoding, and querying by hash IDs.

**New features:**
- `getHashId()` — encode a model's primary key into a hash ID
- `hash_id` — computed attribute accessor
- `findByHashId()` — static method to find a model by its hash ID
- `decodeHashId()` — static method to decode a hash ID to its original value
- `whereHashIds()` — query scope accepting a string, array, or Collection
- Configurable per-model connection via `$connectionHashId` property or `getConnectionHashId()` method

**Tests:**
- 10 tests covering encoding, decoding, attribute access, default/custom connections, and the query scope (single, array, Collection, and invalid hash)

**Docs:**
- Added an Eloquent Model Trait section to the README with setup, usage, and query scope examples